### PR TITLE
Add command to deploy the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -349,12 +349,21 @@
         "command": "pgproj.add.new",
         "title": "New PostgreSQL Project",
         "category": "PostgreSQLProject"
+      },
+      {
+        "command": "pgproj.deploy.current",
+        "title": "Deploy",
+        "category": "PostgreSQLProject"
       }
     ],
     "menus": {
       "commandPalette": [
         {
           "command": "pgproj.build.current",
+          "when": "resourceExtname == .pgproj"
+        },
+        {
+          "command": "pgproj.deploy.current",
           "when": "resourceExtname == .pgproj"
         },
         {
@@ -368,6 +377,10 @@
           "when": "resourceExtname == .pgproj"
         },
         {
+          "command": "pgproj.deploy.current",
+          "when": "resourceExtname == .pgproj"
+        },
+        {
           "command": "pgproj.add.new",
           "when": "explorerResourceIsFolder"
         }
@@ -375,6 +388,10 @@
       "editor/context": [
         {
           "command": "pgproj.build.current",
+          "when": "resourceExtname == .pgproj"
+        },
+        {
+          "command": "pgproj.deploy.current",
           "when": "resourceExtname == .pgproj"
         }
       ]

--- a/src/CommandObserver.ts
+++ b/src/CommandObserver.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import * as Constants from './constants';
 import { Telemetry } from './telemetry';
 
-const msbuildOutputRegex = /^(,)?(((?<origin>([^\s].*))):|())\s*(?<subcategory>(()|([^:]*? )))(?<category>(error|warning))(\s*(?<code>[^: ]*))?\s*:\s*(?<text>.*)$/gm;
+const msbuildOutputRegex = /^\s*([\d]>)?(((?<origin>([^\s].*))):|())\s*(?<subcategory>(()|([^:]*? )))(?<category>(error|warning))(\s*(?<code>[^: ]*))?\s*:\s*(?<text>.*)$/gm;
 const lineRegex = /^(?<origin>([^\s].*))(\((?<linedetails>(\d+|\d+-\d+|\d+,\d+((-\d+)?)|\d+,\d+,\d+,\d+))\))$/;
 
 export class CommandObserver {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -133,11 +133,9 @@ async function buildProjects(dotNetSdk: DotNetInfo, projects: string[], commandO
 			}
 			await dotnetBuild(dotNetSdk, project, commandObserver, cancelToken).then(() => {
 				successProjectCount++;
-				commandObserver.logToOutputChannel(localize('extension.buildEndMessage', 'Done building project {0}\n', project));
 				buildResult.push({ project: project, status: buildStatus.Success })
 			}, () => {
 				failedProjectCount++;
-				commandObserver.logToOutputChannel(localize('extension.buildFailMessage', 'Done building project {0} -- FAILED\n', project));
 				buildResult.push({ project: project, status: buildStatus.Failure })
 			});
 		}
@@ -168,8 +166,7 @@ async function validateProjectSDK(projects: string[], commandObserver: CommandOb
 }
 
 async function dotnetBuild(dotNetSdk: DotNetInfo, project: string, commandObserver: CommandObserver, cancelToken: vscode.CancellationToken): Promise<void> {
-	let args = ['build', project];
-	commandObserver.logToOutputChannel(localize('extension.buildStartMessage', 'Build started: Project: {0}', project));
+	let args = ['build', project, '-v', 'n'];
 	await runDotNetCommand(dotNetSdk, args, commandObserver, cancelToken);
 }
 

--- a/src/commonHelper.ts
+++ b/src/commonHelper.ts
@@ -19,6 +19,14 @@ const enum sdkReference {
 	Element = 2
 };
 
+export const enum buildStatus {
+	Success = 1,
+	Failure = 2,
+	Skipped = 3
+}
+
+export type BuildResult = {project: string, status: buildStatus};
+
 export type ProjectInformation = {
 	path: string;
 	sdkVersion: string;

--- a/src/dotnet.ts
+++ b/src/dotnet.ts
@@ -96,7 +96,10 @@ export async function runDotNetCommand(dotNetSdk: DotNetInfo, args: string[], co
 		handleData(dotnet.stdout);
 		handleData(dotnet.stderr);
 
-		dotnet.on('close', () => {
+		dotnet.on('close', (code) => {
+			if (code === 1) {
+				reject();
+			}
 			resolve();
 		});
 


### PR DESCRIPTION
Adding a new command to deploy a postgreSQL project. User can right click on the pgproj file in editor or explorer and also run the command via command palette.
The command will first build the project, if successful it will try and find the file to deploy which will be projectName.sql (We do this as we do not know the path of the script file) then it opens the connectionDialog with only PostgreSQL and try to deploy the script if connection was successful.